### PR TITLE
Makes the project build in modern environments

### DIFF
--- a/tty.c
+++ b/tty.c
@@ -52,7 +52,7 @@ flag_t timer_intr_enabled = 0;
 int special_keys[SDLK_LAST], shifted[256];
 
 static tty_pending_int = 0;
-unsigned long pending_interrupts;
+extern unsigned long pending_interrupts;
 tty_open()
 {
     int i;


### PR DESCRIPTION
@emestee 
In Ubuntu 23.04
Linker wasn't happy with this:

```/usr/bin/ld: tty.o:/home-net/alext/Devel/Virtual/bk-emulator/tty.c:55: multiple definition of `pending_interrupts'; service.o:/home-net/alext/Devel/Virtual/bk-emulator/service.c:24: first defined here collect2: error: ld returned 1 exit status```