### PR TITLE
Upgrade to SDL2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ readtape
 pngtorba
 irps.log
 everything
+/.idea

--- a/MAC-BUILD.md
+++ b/MAC-BUILD.md
@@ -1,0 +1,28 @@
+# Mac Build Instructions
+
+Instructions for building emulator on MacOS.
+
+Emulator uses following libraries:
+* [SDL2](https://www.libsdl.org/) library to implement integration with display, sound and input devices.
+* [gettext](https://www.gnu.org/software/gettext/) library to implement internationalization.
+
+To install those libraries using [Homebrew](https://brew.sh/) issue this command:
+```shell
+brew instal sdl2 gettext
+```
+
+Find where SDL library was installed, it should look something like that `/usr/local/Cellar/sdl2/2.28.4` although version number
+will likely be different. This location will be needed for adjustments in the `Makefile`.
+
+Open `Makefile` for editing and make following changes:
+* Change `CC` variable definition to add location of the include folder of the SDL2
+  library, assuming library is located at same location as above add this ` -I/usr/local/Cellar/sdl2/2.28.4/include`.
+* Replace `/usr/lib/x86_64-linux-gnu/libSDL.so` with `/usr/local/lib/libSDL2.dylib`
+* Uncomment line `GETTEXT_LIB = /usr/local/lib/libintl.dylib`
+
+Now if you run make it should compile successfully.
+
+You should be able to start emulator by issuing command:
+```shell
+BK_PATH=Rom ./bk -1 -c
+```

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@
 # Change as needed
 #
 
-CC = gcc -std=gnu89
+CC = gcc -std=gnu89 -Wno-error=implicit-function-declaration -Wno-error=return-type -I/usr/local/Cellar/sdl2/2.28.4/include
 LD = gcc
 CFLAGS = -g -DSHIFTS_ALLOWED -DEIS_ALLOWED
 # CFLAGS = -O4 -fomit-frame-pointer # -DSHIFTS_ALLOWED
@@ -73,7 +73,7 @@ icon.c: pngtorgba bk.png
 	if [ ! -s icon.c ] ; then ./pngtorgba bk.png > icon.c ; fi
 
 $(TARGET):	$(OBJS)
-	$(LD) $(CFLAGS) -o $(TARGET) $(OBJS) /usr/lib/x86_64-linux-gnu/libSDL.so  -lpthread
+	$(LD) $(CFLAGS) -o $(TARGET) $(OBJS) /usr/local/Cellar/sdl2/2.28.4/lib/libSDL2.dylib -lpthread
 
 readtape: readtape.c
 	$(CC) $(CFLAGS) -o readtape readtape.c

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@
 # Change as needed
 #
 
-CC = gcc -std=gnu89 -Wno-error=implicit-function-declaration -Wno-error=return-type -I/usr/local/Cellar/sdl2/2.28.4/include
+CC = gcc -std=gnu89 -Wno-error=implicit-function-declaration -Wno-error=return-type # -I/usr/local/Cellar/sdl2/2.28.4/include
 LD = gcc
 CFLAGS = -g -DSHIFTS_ALLOWED -DEIS_ALLOWED
 # CFLAGS = -O4 -fomit-frame-pointer # -DSHIFTS_ALLOWED
@@ -57,6 +57,7 @@ OBJS =	access.o boot.o branch.o conf.o covox.o double.o ea.o itab.o icon.o \
 INCS =	defines.h scr.h conf.h emu2149.h emutypes.h
 USRCS = readtape.c maketape.c pngtorgba.c
 TEXTS =	README.html configure.in icon.c
+# GETTEXT_LIB = /usr/local/lib/libintl.dylib
 
 #
 # Build Rules
@@ -73,13 +74,13 @@ icon.c: pngtorgba bk.png
 	if [ ! -s icon.c ] ; then ./pngtorgba bk.png > icon.c ; fi
 
 $(TARGET):	$(OBJS)
-	$(LD) $(CFLAGS) -o $(TARGET) $(OBJS) /usr/local/Cellar/sdl2/2.28.4/lib/libSDL2.dylib /usr/local/Cellar/gettext/0.22.3/lib/libintl.dylib -lpthread
+	$(LD) $(CFLAGS) -o $(TARGET) $(OBJS) /usr/lib/x86_64-linux-gnu/libSDL.so $(GETTEXT_LIB) -lpthread
 
 readtape: readtape.c
-	$(CC) $(CFLAGS) -o readtape /usr/local/Cellar/gettext/0.22.3/lib/libintl.dylib readtape.c
+	$(CC) $(CFLAGS) -o readtape $(GETTEXT_LIB) readtape.c
 
 maketape: maketape.c
-	$(CC) $(CFLAGS) -o maketape /usr/local/Cellar/gettext/0.22.3/lib/libintl.dylib maketape.c
+	$(CC) $(CFLAGS) -o maketape $(GETTEXT_LIB) maketape.c
 
 #
 # Cool Utilities

--- a/Makefile
+++ b/Makefile
@@ -73,13 +73,13 @@ icon.c: pngtorgba bk.png
 	if [ ! -s icon.c ] ; then ./pngtorgba bk.png > icon.c ; fi
 
 $(TARGET):	$(OBJS)
-	$(LD) $(CFLAGS) -o $(TARGET) $(OBJS) /usr/local/Cellar/sdl2/2.28.4/lib/libSDL2.dylib -lpthread
+	$(LD) $(CFLAGS) -o $(TARGET) $(OBJS) /usr/local/Cellar/sdl2/2.28.4/lib/libSDL2.dylib /usr/local/Cellar/gettext/0.22.3/lib/libintl.dylib -lpthread
 
 readtape: readtape.c
-	$(CC) $(CFLAGS) -o readtape readtape.c
+	$(CC) $(CFLAGS) -o readtape /usr/local/Cellar/gettext/0.22.3/lib/libintl.dylib readtape.c
 
 maketape: maketape.c
-	$(CC) $(CFLAGS) -o maketape maketape.c
+	$(CC) $(CFLAGS) -o maketape /usr/local/Cellar/gettext/0.22.3/lib/libintl.dylib maketape.c
 
 #
 # Cool Utilities

--- a/README.md
+++ b/README.md
@@ -76,4 +76,6 @@ you into the emulator's debugger. To load a game from a binary file (assuming yo
 
 `g 1000`
 
+For instructions on how to compile on Mac use this link: [MAC-BUILD.md](./MAC-BUILD.md)
+
 Please feel free to contact me if you are curious about this. I will do my best to try and answer your questions.

--- a/main.c
+++ b/main.c
@@ -30,7 +30,7 @@
 
 #include "defines.h"
 #include "scr.h"
-#include <SDL/SDL.h>
+#include <SDL2/SDL.h>
 #include <libintl.h>
 #include <locale.h>
 #include <sys/time.h>

--- a/mouse.c
+++ b/mouse.c
@@ -39,8 +39,7 @@ mouse_event(SDL_Event * pev) {
 		if (pev->button.button == 3) {
 			/* middle button switches grab mode */
 			grab_mode ^= 1;
-	 		SDL_SetRelativeMouseMode(grab_mode ? SDL_TRUE : SDL_FALSE);
-			//SDL_WM_GrabInput(grab_mode ? SDL_GRAB_ON : SDL_GRAB_OFF);			return;
+			SDL_SetRelativeMouseMode(grab_mode ? SDL_TRUE : SDL_FALSE);
 		}
 		mouse_button_state |= mouse_but0 << pev->button.button;
 		break;

--- a/mouse.c
+++ b/mouse.c
@@ -1,5 +1,5 @@
 #include "defines.h"
-#include "SDL/SDL.h"
+#include "SDL2/SDL.h"
 
 #define LOGARITHMIC
 
@@ -39,7 +39,8 @@ mouse_event(SDL_Event * pev) {
 		if (pev->button.button == 3) {
 			/* middle button switches grab mode */
 			grab_mode ^= 1;
-			SDL_WM_GrabInput(grab_mode ? SDL_GRAB_ON : SDL_GRAB_OFF);			return;
+	 		SDL_SetRelativeMouseMode(grab_mode ? SDL_TRUE : SDL_FALSE);
+			//SDL_WM_GrabInput(grab_mode ? SDL_GRAB_ON : SDL_GRAB_OFF);			return;
 		}
 		mouse_button_state |= mouse_but0 << pev->button.button;
 		break;

--- a/readtape.c
+++ b/readtape.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <libintl.h>
 #include <locale.h>
 #define _(String) gettext (String)

--- a/scr.c
+++ b/scr.c
@@ -276,9 +276,8 @@ scr_switch(int hsize, int vsize) {
 	}
     }
 
-    if (restore || old_hor != horsize || old_vert != vertsize) { 
-	window = SDL_CreateWindow("blah", SDL_WINDOWPOS_UNDEFINED,
-                          SDL_WINDOWPOS_UNDEFINED, horsize, vertsize, SCREEN_FLAGS);	
+    if (restore || old_hor != horsize || old_vert != vertsize) {
+        screen = SDL_GetWindowSurface(window);
     }
 
     setup_bases();   

--- a/scr.c
+++ b/scr.c
@@ -5,6 +5,7 @@
 #define _(String) gettext (String)
 
 SDL_Window * screen;
+SDL_Renderer * renderer;
 flag_t cflag = 0, fullscreen = 0;
 int cur_shift = 0;
 int cur_width = 0;	/* 0 = narrow, !0 = wide */
@@ -176,13 +177,17 @@ scr_init() {
     if (init_done) return;
     init_done = 1;
 
-    SDL_WM_SetIcon(SDL_CreateRGBSurfaceFrom(bk_icon, bk_icon_width,
+    SDL_SetWindowIcon(screen, SDL_CreateRGBSurfaceFrom(bk_icon, bk_icon_width,
 			bk_icon_height, 32, bk_icon_width*4,
-			0xff000000, 0xff0000, 0xff00, 0xff),
-	compute_icon_mask());
+			0xff000000, 0xff0000, 0xff00, 0xff));
+    //SDL_WM_SetIcon(SDL_CreateRGBSurfaceFrom(bk_icon, bk_icon_width,
+    //           bk_icon_height, 32, bk_icon_width*4,
+    //           0xff000000, 0xff0000, 0xff00, 0xff),
+	//compute_icon_mask());
 	
     screen = SDL_CreateWindow("blah", SDL_WINDOWPOS_UNDEFINED,
                           SDL_WINDOWPOS_UNDEFINED, horsize, vertsize, SCREEN_FLAGS);
+    renderer = SDL_CreateRenderer(screen, -1, SDL_RENDERER_SOFTWARE);
     //screen = SDL_SetVideoMode(horsize, vertsize, 0, SCREEN_FLAGS);
     if (screen == NULL) {
         fprintf(stderr, _("Couldn't set up video: %s\n"),
@@ -200,8 +205,13 @@ scr_init() {
     active_palette = bkmodel ? 15 : 0;
 
     SDL_Surface * screen_surface = SDL_GetWindowSurface(screen);
+    if (screen_surface == 0) {
+        fprintf(stderr, _("Failed to get surface from window: %s\n"), SDL_GetError());
+        exit(1);
+    }
     if (screen_surface->format->BitsPerPixel == 8) {
-	SDL_SetColors(screen, palettes[active_palette], 0, 5);
+	//SDL_SetColors(screen, palettes[active_palette], 0, 5);
+    SDL_SetPaletteColors(screen_surface->format->palette, palettes[active_palette], 0, 5);
     }
 
     /* Create palettized surfaces for scan lines for the highest possible
@@ -356,7 +366,8 @@ scr_refresh_bk0010(unsigned shift, unsigned full) {
 				dstrect.y++;
 			} while (n--);
 			if (!update_all) {
-				SDL_UpdateRect(screen, 0, vertbase[i], width, vertstretch);
+				//SDL_UpdateRect(screen, 0, vertbase[i], width, vertstretch);
+                SDL_RenderPresent(renderer);
 			}
 		}
 	}
@@ -372,7 +383,8 @@ scr_refresh_bk0010(unsigned shift, unsigned full) {
 	cur_width = full;
 	cur_shift = shift;
 	if (update_all) {
-		SDL_Flip(screen);
+		//SDL_Flip(screen);
+        SDL_RenderPresent(renderer);
 	}
 	scr_dirty = 0;
 }
@@ -410,7 +422,8 @@ scr_refresh_bk0011_1(unsigned shift, unsigned full) {
 			}
 			SDL_BlitSurface(l, &srcrect, screen, &dstrect);
 			if (!update_all) {
-				SDL_UpdateRect(screen, 0, dstrect.y, width, 1);
+				//SDL_UpdateRect(screen, 0, dstrect.y, width, 1);
+                SDL_RenderPresent(renderer);
 			}
 		}
 	}
@@ -425,7 +438,8 @@ scr_refresh_bk0011_1(unsigned shift, unsigned full) {
 	cur_width = full;
 	cur_shift = shift;
 	if (update_all) {
-		SDL_Flip(screen);
+		//SDL_Flip(screen);
+        SDL_RenderPresent(renderer);
 	}
 	scr_dirty = 0;
 	change_req >>= 1;
@@ -462,7 +476,8 @@ scr_refresh_bk0011_2(unsigned shift, unsigned full) {
 			}
 			SDL_BlitSurface(l, &srcrect, screen, &dstrect);
 			if (!update_all) {
-				SDL_UpdateRect(screen, 0, dstrect.y, width, 1);
+				//SDL_UpdateRect(screen, 0, dstrect.y, width, 1);
+                SDL_RenderPresent(renderer);
 			}
 		}
 	}
@@ -477,7 +492,8 @@ scr_refresh_bk0011_2(unsigned shift, unsigned full) {
 	cur_width = full;
 	cur_shift = shift;
 	if (update_all) {
-		SDL_Flip(screen);
+		//SDL_Flip(screen);
+        SDL_RenderPresent(renderer);
 	}
 	scr_dirty = 0;
 	change_req >>= 1;

--- a/scr.c
+++ b/scr.c
@@ -5,8 +5,8 @@
 #define _(String) gettext (String)
 
 SDL_Window * window;
-SDL_Surface * screen;
 SDL_Renderer * renderer;
+SDL_Surface * screen;
 flag_t cflag = 0, fullscreen = 0;
 int cur_shift = 0;
 int cur_width = 0;	/* 0 = narrow, !0 = wide */
@@ -55,9 +55,6 @@ int lower_porch = 3;	/* Default */
 
 #define LINES_TOTAL     (256+upper_porch+lower_porch)
 
-// It is unlikely that we get a hardware surface, but one can hope
-//#define SCREEN_FLAGS    \
-//	(SDL_HWSURFACE|SDL_HWACCEL|SDL_ASYNCBLIT|SDL_DOUBLEBUF|SDL_ANYFORMAT|SDL_HWPALETTE|(fullscreen ? SDL_WINDOW_FULLSCREEN : SDL_RESIZABLE))
 #define SCREEN_FLAGS (fullscreen ? SDL_WINDOW_FULLSCREEN : SDL_WINDOW_RESIZABLE)
 
 
@@ -177,29 +174,23 @@ scr_init() {
     if (init_done) return;
     init_done = 1;
 
-    //SDL_WM_SetIcon(SDL_CreateRGBSurfaceFrom(bk_icon, bk_icon_width,
-    //           bk_icon_height, 32, bk_icon_width*4,
-    //           0xff000000, 0xff0000, 0xff00, 0xff),
-	//compute_icon_mask());
-	
-    window = SDL_CreateWindow("blah", SDL_WINDOWPOS_UNDEFINED,
-                          SDL_WINDOWPOS_UNDEFINED, horsize, vertsize, SCREEN_FLAGS);
-    SDL_SetWindowIcon(window, SDL_CreateRGBSurfaceFrom(bk_icon, bk_icon_width,
-                                                       bk_icon_height, 32, bk_icon_width*4,
-                                                       0xff000000, 0xff0000, 0xff00, 0xff));
-    renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_SOFTWARE);
-    //screen = SDL_SetVideoMode(horsize, vertsize, 0, SCREEN_FLAGS);
-    if (renderer == NULL) {
-        fprintf(stderr, _("Couldn't set up video: %s\n"),
-                        SDL_GetError());
-        exit(1);
-    }
+	window = SDL_CreateWindow("BK0010", SDL_WINDOWPOS_UNDEFINED,
+							  SDL_WINDOWPOS_UNDEFINED, horsize, vertsize, SCREEN_FLAGS);
+	SDL_SetWindowIcon(window, SDL_CreateRGBSurfaceFrom(bk_icon, bk_icon_width,
+													   bk_icon_height, 32, bk_icon_width*4,
+													   0xff000000, 0xff0000, 0xff00, 0xff));
+	renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_SOFTWARE);
+	if (renderer == NULL) {
+		fprintf(stderr, _("Couldn't set up video: %s\n"),
+						 SDL_GetError());
+		exit(1);
+	}
 
     /* Translation disabled because of an SDL bug */
     if (bkmodel == 0) {
-    	SDL_SetWindowTitle(window, "BK-0010"); }
+		SDL_SetWindowTitle(window, "BK-0010"); }
     else {
-    	SDL_SetWindowTitle(window, "BK-0011M");
+		SDL_SetWindowTitle(window, "BK-0011M");
     }
 
     active_palette = bkmodel ? 15 : 0;
@@ -210,8 +201,7 @@ scr_init() {
         exit(1);
     }
     if (screen->format->BitsPerPixel == 8) {
-	//SDL_SetColors(screen, palettes[active_palette], 0, 5);
-    SDL_SetPaletteColors(screen->format->palette, palettes[active_palette], 0, 5);
+		SDL_SetPaletteColors(screen->format->palette, palettes[active_palette], 0, 5);
     }
 
     /* Create palettized surfaces for scan lines for the highest possible
@@ -225,9 +215,7 @@ scr_init() {
 			SDL_GetError());
 		exit(1);
 	}
-	//SDL_SetPalette(lines[i], SDL_LOGPAL,
-	//	palettes[active_palette], 0, 5);
-        SDL_SetPaletteColors(lines[i]->format->palette, palettes[active_palette], 0, 5);
+	SDL_SetPaletteColors(lines[i]->format->palette, palettes[active_palette], 0, 5);
 	dirty[i] = 0;
     }
     SDL_ShowCursor(SDL_DISABLE);
@@ -277,7 +265,7 @@ scr_switch(int hsize, int vsize) {
     }
 
     if (restore || old_hor != horsize || old_vert != vertsize) {
-        screen = SDL_GetWindowSurface(window);
+		screen = SDL_GetWindowSurface(window);
     }
 
     setup_bases();   
@@ -361,13 +349,11 @@ scr_refresh_bk0010(unsigned shift, unsigned full) {
 		if (dirty[line] | blit_all) {
 			int n = vertstretch-1;
 			do {
-
 				SDL_BlitSurface(l, &srcrect, screen, &dstrect);
 				dstrect.y++;
 			} while (n--);
 			if (!update_all) {
-				//SDL_UpdateRect(screen, 0, vertbase[i], width, vertstretch);
-                SDL_RenderPresent(renderer);
+				SDL_RenderPresent(renderer);
 			}
 		}
 	}
@@ -383,8 +369,7 @@ scr_refresh_bk0010(unsigned shift, unsigned full) {
 	cur_width = full;
 	cur_shift = shift;
 	if (update_all) {
-		//SDL_Flip(screen);
-        SDL_RenderPresent(renderer);
+		SDL_RenderPresent(renderer);
 	}
 	scr_dirty = 0;
 }
@@ -416,14 +401,11 @@ scr_refresh_bk0011_1(unsigned shift, unsigned full) {
 		dstrect.y = i;
 		if (dirty[physline] | blit_all) {
 			if (do_palette) {
-                SDL_SetPaletteColors(l->format->palette, palettes[req_palette[2*i+(i&1)]], 0, 5);
-				//SDL_SetPalette(l, SDL_LOGPAL,
-			//		palettes[req_palette[2*i+(i&1)]], 0, 5);
+				SDL_SetPaletteColors(l->format->palette, palettes[req_palette[2*i+(i&1)]], 0, 5);
 			}
 			SDL_BlitSurface(l, &srcrect, screen, &dstrect);
 			if (!update_all) {
-				//SDL_UpdateRect(screen, 0, dstrect.y, width, 1);
-                SDL_RenderPresent(renderer);
+				SDL_RenderPresent(renderer);
 			}
 		}
 	}
@@ -438,8 +420,7 @@ scr_refresh_bk0011_1(unsigned shift, unsigned full) {
 	cur_width = full;
 	cur_shift = shift;
 	if (update_all) {
-		//SDL_Flip(screen);
-        SDL_RenderPresent(renderer);
+		SDL_RenderPresent(renderer);
 	}
 	scr_dirty = 0;
 	change_req >>= 1;
@@ -470,14 +451,11 @@ scr_refresh_bk0011_2(unsigned shift, unsigned full) {
 		dstrect.y = i;
 		if (dirty[physline] | blit_all) {
 			if (do_palette) {
-                                SDL_SetPaletteColors(l->format->palette, palettes[req_palette[2*j+(i&1)]], 0, 5);
-				//SDL_SetPalette(l, SDL_LOGPAL,
-				//	palettes[req_palette[2*j+(i&1)]], 0, 5);
+				SDL_SetPaletteColors(l->format->palette, palettes[req_palette[2*j+(i&1)]], 0, 5);
 			}
 			SDL_BlitSurface(l, &srcrect, screen, &dstrect);
 			if (!update_all) {
-				//SDL_UpdateRect(screen, 0, dstrect.y, width, 1);
-                SDL_RenderPresent(renderer);
+				SDL_RenderPresent(renderer);
 			}
 		}
 	}
@@ -492,8 +470,7 @@ scr_refresh_bk0011_2(unsigned shift, unsigned full) {
 	cur_width = full;
 	cur_shift = shift;
 	if (update_all) {
-		//SDL_Flip(screen);
-        SDL_RenderPresent(renderer);
+		SDL_RenderPresent(renderer);
 	}
 	scr_dirty = 0;
 	change_req >>= 1;

--- a/sound.c
+++ b/sound.c
@@ -1,8 +1,8 @@
 #include "defines.h"
 #include <stdio.h>
-#include <SDL/SDL.h>
-#include <SDL/SDL_thread.h>
-#include <SDL/SDL_mutex.h>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_thread.h>
+#include <SDL2/SDL_mutex.h>
 #include <libintl.h>
 #define _(String) gettext (String)
 

--- a/tty.c
+++ b/tty.c
@@ -290,7 +290,7 @@ static int ar2 = 0;
 tty_keyevent(SDL_Event * pev) {
 	int k, c, scan_code;
 	k = pev->key.keysym.sym;
-    scan_code = pev->key.keysym.scancode;
+	scan_code = pev->key.keysym.scancode;
 	if (SDLK_UNKNOWN == k) {
 	    return;
 	}

--- a/tty.c
+++ b/tty.c
@@ -60,42 +60,42 @@ tty_open()
     for (i = 0; i < SDL_NUM_SCANCODES; i++) {
 	special_keys[i] = -1;
     }
-    special_keys[SDLK_BACKSPACE] = 030;
-    special_keys[SDLK_TAB] = 011;
-    special_keys[SDLK_RETURN] = 012;
-    special_keys[SDLK_CLEAR] = 014;        /* sbr */
+    special_keys[SDL_SCANCODE_BACKSPACE] = 030;
+    special_keys[SDL_SCANCODE_TAB] = 011;
+    special_keys[SDL_SCANCODE_RETURN] = 012;
+    special_keys[SDL_SCANCODE_CLEAR] = 014;        /* sbr */
 
-    for (i = SDLK_NUMLOCKCLEAR; i <= SDLK_APPLICATION; i++)
+    for (i = SDL_SCANCODE_NUMLOCKCLEAR; i <= SDL_SCANCODE_APPLICATION; i++)
 	special_keys[i] = TTY_NOTHING;
 
-    special_keys[SDLK_SCROLLLOCK] = TTY_SWITCH;
+    special_keys[SDL_SCANCODE_SCROLLLOCK] = TTY_SWITCH;
     //special_keys[SDLK_LSUPER] = TTY_AR2;
-    special_keys[SDLK_LALT] = TTY_AR2;
-    special_keys[SDLK_ESCAPE] = TTY_STOP;
+    special_keys[SDL_SCANCODE_LALT] = TTY_AR2;
+    special_keys[SDL_SCANCODE_ESCAPE] = TTY_STOP;
 
-    special_keys[SDLK_DELETE] = -1;
-    special_keys[SDLK_LEFT] = 010;
-    special_keys[SDLK_UP] = 032;
-    special_keys[SDLK_RIGHT] = 031;
-    special_keys[SDLK_DOWN] = 033;
-    special_keys[SDLK_HOME] = 023;         /* vs */
-    special_keys[SDLK_PAGEUP] = -1;     /* PgUp */
-    special_keys[SDLK_PAGEDOWN] = -1;    /* PgDn */
-    special_keys[SDLK_END] = -1;
-    special_keys[SDLK_INSERT] = -1;
-    special_keys[SDLK_PAUSE] = TTY_STOP;
-    special_keys[SDLK_F1] = 0201;          /* povt */
-    special_keys[SDLK_F2] = 003;           /* kt */
-    special_keys[SDLK_F3] = 0213;          /* -|--> */
-    special_keys[SDLK_F4] = 026;           /* |<--- */
-    special_keys[SDLK_F5] = 027;           /* |---> */
-    special_keys[SDLK_F6] = 0202;          /* ind su */
-    special_keys[SDLK_F7] = 0204;          /* blk red */
-    special_keys[SDLK_F8] = 0200;          /* shag */
-    special_keys[SDLK_F9] = 014;           /* sbr */
-    special_keys[SDLK_F10] = TTY_STOP;
-    special_keys[SDLK_F11] = TTY_RESET;
-    special_keys[SDLK_F12] = TTY_DOWNLOAD;
+    special_keys[SDL_SCANCODE_DELETE] = -1;
+    special_keys[SDL_SCANCODE_LEFT] = 010;
+    special_keys[SDL_SCANCODE_UP] = 032;
+    special_keys[SDL_SCANCODE_RIGHT] = 031;
+    special_keys[SDL_SCANCODE_DOWN] = 033;
+    special_keys[SDL_SCANCODE_HOME] = 023;         /* vs */
+    special_keys[SDL_SCANCODE_PAGEUP] = -1;     /* PgUp */
+    special_keys[SDL_SCANCODE_PAGEDOWN] = -1;    /* PgDn */
+    special_keys[SDL_SCANCODE_END] = -1;
+    special_keys[SDL_SCANCODE_INSERT] = -1;
+    special_keys[SDL_SCANCODE_PAUSE] = TTY_STOP;
+    special_keys[SDL_SCANCODE_F1] = 0201;          /* povt */
+    special_keys[SDL_SCANCODE_F2] = 003;           /* kt */
+    special_keys[SDL_SCANCODE_F3] = 0213;          /* -|--> */
+    special_keys[SDL_SCANCODE_F4] = 026;           /* |<--- */
+    special_keys[SDL_SCANCODE_F5] = 027;           /* |---> */
+    special_keys[SDL_SCANCODE_F6] = 0202;          /* ind su */
+    special_keys[SDL_SCANCODE_F7] = 0204;          /* blk red */
+    special_keys[SDL_SCANCODE_F8] = 0200;          /* shag */
+    special_keys[SDL_SCANCODE_F9] = 014;           /* sbr */
+    special_keys[SDL_SCANCODE_F10] = TTY_STOP;
+    special_keys[SDL_SCANCODE_F11] = TTY_RESET;
+    special_keys[SDL_SCANCODE_F12] = TTY_DOWNLOAD;
     for (i = 0; i < 256; i++) {
 	shifted[i] = i;
     }

--- a/tty.c
+++ b/tty.c
@@ -335,6 +335,10 @@ tty_keyevent(SDL_Event * pev) {
 		c = special_keys[scan_code];
 	    }
 	} else {
+        if (k > 255) {
+            // non character key
+            return;
+        }
 	    // Keysym follows ASCII
 	    c = k;
 	    if ((pev->key.keysym.mod & KMOD_CAPS) && isalpha(c)) {

--- a/tty.c
+++ b/tty.c
@@ -289,19 +289,20 @@ stop_key() {
 
 static int ar2 = 0;
 tty_keyevent(SDL_Event * pev) {
-	int k, c;
+	int k, c, scan_code;
 	k = pev->key.keysym.sym;
+    scan_code = pev->key.keysym.scancode;
 	if (SDLK_UNKNOWN == k) {
 	    return;
 	}
 	if(pev->type == SDL_KEYUP) {
 	    key_pressed = 0100;
-	    if (special_keys[k] == TTY_AR2) ar2 = 0;
+	    if (special_keys[scan_code] == TTY_AR2) ar2 = 0;
 	    return;
 	}
 	/* modifier keys handling */
-	if (special_keys[k] != -1) {
-	    switch (special_keys[k]) {
+	if (special_keys[scan_code] != -1) {
+	    switch (special_keys[scan_code]) {
 	    case TTY_STOP:
 		stop_key();     /* STOP is NMI */
 		return;
@@ -331,7 +332,7 @@ tty_keyevent(SDL_Event * pev) {
 		scr_switch(0, 0);
 		return;
 	    default:
-		c = special_keys[k];
+		c = special_keys[scan_code];
 	    }
 	} else {
 	    // Keysym follows ASCII
@@ -370,7 +371,6 @@ tty_recv()
     /* fprintf(stderr, "Polling events..."); */
     while (SDL_PollEvent(&ev)) {
 	extern void mouse_event(SDL_Event * pev);
-
 	    switch (ev.type) {
 	    case SDL_KEYDOWN: case SDL_KEYUP:
 		tty_keyevent(&ev);

--- a/tty.c
+++ b/tty.c
@@ -20,7 +20,6 @@
 
 #include "defines.h"
 #include "SDL2/SDL.h"
-//#include "SDL2/SDL_keysym.h"
 #include "SDL2/SDL_events.h"
 #include <ctype.h>
 #include <libintl.h>
@@ -69,7 +68,7 @@ tty_open()
 	special_keys[i] = TTY_NOTHING;
 
     special_keys[SDL_SCANCODE_SCROLLLOCK] = TTY_SWITCH;
-    //special_keys[SDLK_LSUPER] = TTY_AR2;
+    special_keys[SDL_SCANCODE_LGUI] = TTY_AR2;
     special_keys[SDL_SCANCODE_LALT] = TTY_AR2;
     special_keys[SDL_SCANCODE_ESCAPE] = TTY_STOP;
 
@@ -335,10 +334,10 @@ tty_keyevent(SDL_Event * pev) {
 		c = special_keys[scan_code];
 	    }
 	} else {
-        if (k > 255) {
-            // non character key
-            return;
-        }
+		if (k > 255) {
+			// non character key
+			return;
+		}
 	    // Keysym follows ASCII
 	    c = k;
 	    if ((pev->key.keysym.mod & KMOD_CAPS) && isalpha(c)) {
@@ -379,29 +378,22 @@ tty_recv()
 	    case SDL_KEYDOWN: case SDL_KEYUP:
 		tty_keyevent(&ev);
 		break;
-            case SDL_WINDOWEVENT: {
-            switch (ev.window.event) {
-            case SDL_WINDOWEVENT_RESIZED:
-	  	scr_switch(ev.window.data1, ev.window.data2);
-                break;
-            case SDL_WINDOWEVENT_EXPOSED:
-		scr_dirty  = 256;
-		break;
-            }
-            }
-	    //case SDL_VIDEOEXPOSE:
-	    //case SDL_ACTIVEEVENT:
-		/* the visibility changed */
-	//	scr_dirty  = 256;
-	//	break;
+		case SDL_WINDOWEVENT: {
+			switch (ev.window.event) {
+			case SDL_WINDOWEVENT_RESIZED:
+				scr_switch(ev.window.data1, ev.window.data2);
+				break;
+			case SDL_WINDOWEVENT_EXPOSED:
+				 /* the visibility changed */
+				 scr_dirty  = 256;
+				 break;
+			}
+		}
 	    case SDL_MOUSEBUTTONDOWN:
 	    case SDL_MOUSEBUTTONUP:
 	    case SDL_MOUSEMOTION:
 		mouse_event(&ev);
 		break;
-	    //case SDL_VIDEORESIZE:
-	//	scr_switch(ev.resize.w, ev.resize.h);
-	//	break;
 	    case SDL_QUIT:
 		exit(0);
 	    default:;


### PR DESCRIPTION
Addressing issue #1 migration to more modern SDL2 library.

Mostly followed migration guide from here: https://wiki.libsdl.org/SDL2/MigrationGuide.

Did some testing.  Display and keyboard integration works fine. For display tested wide character and narrow character modes.  Modifier and special keys work as expected. Testing was done on Mac.

Added instructions on how to build and run on Mac.

Please squash it before merging.