### PR TITLE
Some improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ pngtorba
 irps.log
 everything
 /.idea
+*.BIN
+*.OV?
+*.DAT

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ icon.c: pngtorgba bk.png
 	if [ ! -s icon.c ] ; then ./pngtorgba bk.png > icon.c ; fi
 
 $(TARGET):	$(OBJS)
-	$(LD) $(CFLAGS) -o $(TARGET) $(OBJS) /usr/lib/x86_64-linux-gnu/libSDL.so $(GETTEXT_LIB) -lpthread
+	$(LD) $(CFLAGS) -o $(TARGET) $(OBJS) $(shell pkg-config --libs sdl2) $(GETTEXT_LIB) -lpthread
 
 readtape: readtape.c
 	$(CC) $(CFLAGS) -o readtape $(GETTEXT_LIB) readtape.c

--- a/io.c
+++ b/io.c
@@ -49,10 +49,9 @@ d_word word;
 		pagereg_write(word);
 		return OK;
 	}
-	io_sound_val = word & 0300;
+	io_sound_val = (word & 0100) != 0;
 	if (io_sound_val != oldval) {
-		if (fullspeed) io_sound_count = ticks;
-		    io_sound_age = 0;
+     if (fullspeed) io_sound_count = ticks;
 	}
 	/* status, value */
 	tape_write((word >> 7) & 1, (word >> 6) & 1);
@@ -66,10 +65,9 @@ io_bwrite(c_addr addr, d_byte byte) {
 	d_word offset = addr - IO_REG;
 	unsigned oldval = io_sound_val;
 	if (offset == 0) {
-	    io_sound_val = byte & 0300;
+	    io_sound_val = (byte & 0100) != 0;
 	    if (io_sound_val != oldval) {
 		    if (fullspeed) io_sound_count = ticks;
-		    io_sound_age = 0;
 	    }
 	    tape_write((byte >> 7) & 1, (byte >> 6) & 1);
 	    if (telegraph_enabled) {

--- a/main.c
+++ b/main.c
@@ -184,7 +184,7 @@ by the environment variable BK_PATH.\n"), romdir );
 		TICK_RATE = 3000000;
 		break;
 	default: /* Unknown ROM configuration */
-		fprintf( stderr, _("Unknown BK model. Bailing out.\n"), argv[0] );
+		fprintf( stderr, _("Unknown BK model. Bailing out.\n"));
 		exit( -1 );
 	}
 	
@@ -407,7 +407,7 @@ run( int flag )
 		speed = (((double)p->total) / expired );
 	else
 		speed = 0.0;
-	fprintf( stderr, _("Instructions executed: %d\n"), p->total );
+	fprintf( stderr, _("Instructions executed: %lud\n"), p->total );
 	fprintf( stderr, _("Simulation rate: %.5g instructions per second\n"),
 		speed );
 	fprintf( stderr, _("BK speed: %.5g instructions per second\n"),
@@ -466,7 +466,7 @@ int flag;
 		if (traceflag) {
 			extern double io_sound_count;
 			disas(p->regs[PC], buf);
-			if (tracefile) fprintf(tracefile, "%s\t%s\n", buf, state(p));
+			if (tracefile) fprintf(tracefile, "%s\t%d\n", buf, state(p));
 			else printf("%s\n", buf);
 		}
 		result = ll_word( p, p->regs[PC], &p->ir );
@@ -580,7 +580,7 @@ int flag;
 		     * by SDL. If the sound is on, sound buffering
 		     * provides synchronization.
 		     */
-		    if (!fullspeed && !nflag) {
+		    if (!fullspeed) {
 		    	double cur_delta =
 				ticks - SDL_GetTicks() * (TICK_RATE/1000.0);
 			if (cur_delta - timing_delta > TICK_RATE/100) {
@@ -734,26 +734,26 @@ char *monitor11help = _("BK0011M BOS commands:\n\n\
 
     switch( bkmodel ) { /* Make the hints model-specific */
     case 0: /* BK0010 */
-	fprintf(stderr, monitor10help);
+	fprintf(stderr, "%s", monitor10help);
         fprintf(stderr, _(" 'T' - Run built-in tests.\n\n"));
         fprintf(stderr, _("Type 'P M' to quit FOCAL and get the MONITOR prompt.\n"));
         fprintf(stderr, _("Type 'P T' to enter the test mode. 1-5 selects a test.\n\n"));
     break;
     case 1: /* BK0010.01 */
-	fprintf(stderr, monitor10help);
+	fprintf(stderr, "%s", monitor10help);
         fprintf(stderr, _("\nType 'MO' to quit BASIC VILNIUS 1986 and get the MONITOR prompt.\n\n"));
     break;
     case 2: /* BK0010.01+FDD */
-	fprintf(stderr, monitor10help);
+	fprintf(stderr, "%s", monitor10help);
         fprintf(stderr, _("\nType 'S160000' to boot from floppy A:.\n"));
         fprintf(stderr, _("The BASIC ROM is disabled.\n\n"));
     break;
     case 3: /* BK0011M+FDD */
-	fprintf(stderr, monitor11help);
+	fprintf(stderr, "%s", monitor11help);
         fprintf(stderr, _("\nBK-0011M boots automatically from the first floppy drive available.\n\n"));
     break;
     case 4: /* BK0011M */
-	fprintf(stderr, monitor11help);
+	fprintf(stderr, "%s", monitor11help);
     break;
     }
 }

--- a/sound.c
+++ b/sound.c
@@ -6,93 +6,56 @@
 #include <libintl.h>
 #define _(String) gettext (String)
 
-#define SOUND_EXPONENT	(8+io_sound_freq/20000)
-#define SOUND_BUFSIZE   (1<<SOUND_EXPONENT)		/* about 1/43 sec */
+#define SOUND_BUFSIZE   512
 #define MAX_SOUND_AGE	~0	/* always play */ 
 
 unsigned io_max_sound_age = MAX_SOUND_AGE;
-unsigned io_sound_age = MAX_SOUND_AGE;	/* in io_sound_pace's since last change */
-unsigned io_sound_bufsize,
-	io_sound_freq = 11025,
-	io_sound_pace;
+unsigned io_sound_freq = 11025;
 double io_sound_count;
 extern unsigned io_sound_val, covox_age;
 extern unsigned char covox_val;
 extern flag_t nflag, fullspeed;
 
-typedef struct {
-	short * buf;
-	unsigned int ptr;
-} sound_buf_t;
-
-#define NUMBUF 2
-
-sound_buf_t sound_buf[NUMBUF];
-
-SDL_sem * sem;
- 
-int cur_buf;
-
-void callback(void * dummy, Uint8 * outbuf, int len)
-{
-	static int cur_out_buf;
-	if (SDL_SemValue(sem) == NUMBUF) {
-		// Underflow: TODO fill the buffer with silence
-		// fprintf(stderr, "!");
-		return;
-	}
-	memcpy(outbuf, sound_buf[cur_out_buf].buf, len);
-	cur_out_buf = (cur_out_buf + 1) % NUMBUF;
-	SDL_SemPost(sem);
-}
+SDL_AudioDeviceID audioDeviceId;
 
 /* Called after every instruction */
-sound_flush() {
-	if (fullspeed && io_sound_age >= io_max_sound_age && covox_age >= io_max_sound_age) {
-		/* No change in sound bit for a while, nothing to play,
-		 * and drop whatever is in the buffer, 1/21 sec does not
-		 * matter.
-		 */
-		if (sound_buf[cur_buf].ptr != 0) {
-			// TODO: Fill up the buffer with silence
-			// Give the buffer to the callback
-			SDL_SemWait(sem);
-			sound_buf[cur_buf].ptr = 0;
-			cur_buf = (cur_buf + 1) % NUMBUF;
-		}
-		return;
-	}
-	while (ticks >= io_sound_count) {
-		short * p =
-			&sound_buf[cur_buf].buf[sound_buf[cur_buf].ptr++];
-		if (io_sound_age < 1000)
-			*p = io_sound_val + covox_val << 4;
-		else
-			*p = (covox_val << 4) + synth_next();
-		io_sound_count += io_sound_pace;
-		io_sound_age++;
+void sound_flush() {
+	int16_t buf[SOUND_BUFSIZE * 4];
+	int i = 0;
+
+	for (; io_sound_count < ticks; ++i, io_sound_count += TICK_RATE / io_sound_freq) {
+      static float hi_filt = 0.0f;
+      static float lo_filt = 0.0f;
+      int16_t d = 0x7fff * io_sound_val + (covox_val << 4);
+      hi_filt = hi_filt + .25f * (d - hi_filt);
+      lo_filt = lo_filt + .4f * (d - hi_filt - lo_filt);
+   	buf[i] = lo_filt;
 		covox_age++;
-		if (io_sound_bufsize == sound_buf[cur_buf].ptr ||
-			io_sound_age == io_max_sound_age) {
-			SDL_SemWait(sem);
-			sound_buf[cur_buf].ptr = 0;
-			cur_buf = (cur_buf + 1) % NUMBUF;
-			
-		}
 	}
+   if (i == 0)
+     return;
+	SDL_QueueAudio(audioDeviceId, buf, i * sizeof(int16_t));
+   static int cnt = 0;
+   if (cnt++ > 10000)
+     {
+       cnt = 0;
+       if (SDL_GetQueuedAudioSize(audioDeviceId) > 4 * SOUND_BUFSIZE)
+         {
+           printf("The audio queue grew too much.\n");
+           SDL_ClearQueuedAudio(audioDeviceId);
+         }
+     }
 }
 
 void sound_finish() {
 	/* release the write thread so it can terminate */
-	SDL_PauseAudio(1); 
-	SDL_DestroySemaphore(sem);
+	SDL_PauseAudioDevice(audioDeviceId, 1);
 }
 
 SDL_AudioSpec desired;
 
-sound_init() {
-	static init_done = 0;
-	int iarg, i;
+void sound_init() {
+	static int init_done = 0;
 	if (!nflag)
 		return;
 	if (fullspeed) {
@@ -100,8 +63,6 @@ sound_init() {
 		/* otherwise UINT_MAX */
 	}
 	if (init_done) {
-		sound_buf[cur_buf].ptr = 0;
-		io_sound_age = io_max_sound_age;
 		return;
 	}
 	fprintf(stderr, _("sound_init called\n"));
@@ -110,29 +71,15 @@ sound_init() {
 		fprintf(stderr, _("Failed to initialize audio subsystem\n"));
 	}
 
-	desired.format = 16;
+	desired.format = AUDIO_S16;
 	desired.channels = 1;
 	desired.freq = io_sound_freq;
-	desired.samples = io_sound_bufsize = SOUND_BUFSIZE;
-	desired.callback = callback;
-	if (-1 == SDL_OpenAudio(&desired, 0)) {
-		fprintf(stderr, _("Failed to initialize sound, freq %d, %d samples\n"), io_sound_freq, SOUND_BUFSIZE);
-		nflag = 0;
-		return;
-	}
+	desired.samples = SOUND_BUFSIZE;
+	desired.callback = NULL;
+   SDL_AudioSpec obtained;
+   audioDeviceId = SDL_OpenAudioDevice(NULL, 0, &desired, &obtained, 0);
 
-	io_sound_pace = TICK_RATE/io_sound_freq;
-	sem = SDL_CreateSemaphore(NUMBUF);
-
-	for (i = 0; i < NUMBUF; i++) {
-		sound_buf[i].ptr = 0;
-		sound_buf[i].buf = malloc(io_sound_bufsize * sizeof(short));
-	}
-	if (!sound_buf[NUMBUF-1].buf) {
-		fprintf(stderr, _("Failed to allocate sound buffers\n"));
-		exit(1);
-	}
 	atexit(sound_finish);
-	SDL_PauseAudio(0);
+	SDL_PauseAudioDevice(audioDeviceId, 0);
 	init_done = 1;
 }

--- a/tty.c
+++ b/tty.c
@@ -397,7 +397,6 @@ tty_recv()
 	    case SDL_QUIT:
 		exit(0);
 	    default:;
-		fprintf(stderr, _("Unexpected event %d\n"), ev.type);
 	    }
     }
     /* fprintf(stderr, "done\n"); */


### PR DESCRIPTION
- Use pkg-config to link with SDL2.
- Fix minor compilation warnings.
- Remove some spammy log messages.
- Update the sound subsystem to use SDL Audio Queue instead of a ring buffer.

This change is not perfect, I just quickly hacked things together to be able to run the emulator, but I thought if you are interested you may want to merge it to the upstream.